### PR TITLE
Drupal 9 compatibility

### DIFF
--- a/elasticsearch_helper_index_management.info.yml
+++ b/elasticsearch_helper_index_management.info.yml
@@ -3,5 +3,6 @@ type: module
 description: A module for managing indices in elasticsearch.
 core_version_requirement: ^8 || ^9
 core: 8.x
+package: ElasticSearch Helper
 dependencies:
   - elasticsearch_helper

--- a/elasticsearch_helper_index_management.info.yml
+++ b/elasticsearch_helper_index_management.info.yml
@@ -1,6 +1,7 @@
 name: Elasticsearch Helper Index management
 type: module
 description: A module for managing indices in elasticsearch.
+core_version_requirement: ^8 || ^9
 core: 8.x
 dependencies:
   - elasticsearch_helper

--- a/tests/modules/elasticsearch_helper_index_management_test/elasticsearch_helper_index_management_test.info.yml
+++ b/tests/modules/elasticsearch_helper_index_management_test/elasticsearch_helper_index_management_test.info.yml
@@ -3,4 +3,4 @@ type: module
 description: Module for Elasticsearch Helper Index management tests
 core_version_requirement: ^8 || ^9
 core: 8.x
-package: Testing
+package: ElasticSearch Helper

--- a/tests/modules/elasticsearch_helper_index_management_test/elasticsearch_helper_index_management_test.info.yml
+++ b/tests/modules/elasticsearch_helper_index_management_test/elasticsearch_helper_index_management_test.info.yml
@@ -1,5 +1,6 @@
 name: Elasticsearch helper index management test
 type: module
 description: Module for Elasticsearch Helper Index management tests
+core_version_requirement: ^8 || ^9
 core: 8.x
 package: Testing


### PR DESCRIPTION
This PR adds Drupal 9 readiness for elasticsearch_helper_index_management module.

Note:
Marking core_version_requirement: ^8 || ^9 as there is no deprecations introduced after 8.0.x

Checked with [Upgrade status](https://www.drupal.org/project/upgrade_status)