### PR TITLE
Add Index Management link to elasticsearch helper settings page

### DIFF
--- a/elasticsearch_helper_index_management.module
+++ b/elasticsearch_helper_index_management.module
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @file
+ * Hook implementations for elasticsearch_helper_index_management.
+ */
+
+use Drupal\Core\Url;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function elasticsearch_helper_index_management_form_elasticsearch_helper_settings_form_alter(array &$form, FormStateInterface $form_state) {
+  $form['index_management_message'] = [
+    '#type' => 'link',
+    '#url' => Url::fromRoute('elasticsearch_helper_index_management.index_list_controller_display'),
+    '#title' => t('Index Management'),
+  ];
+}


### PR DESCRIPTION
This PR adds Index Management link to elasticsearch_helper settings page.