### PR TITLE
Defined static local task

### DIFF
--- a/elasticsearch_helper_index_management.links.task.yml
+++ b/elasticsearch_helper_index_management.links.task.yml
@@ -1,0 +1,4 @@
+elasticsearch_helper_index_management.index_list_controller_display:
+  title: 'Index Management'
+  route_name: elasticsearch_helper_index_management.index_list_controller_display
+  base_route: elasticsearch_helper.elasticsearch_helper_settings_form


### PR DESCRIPTION
This PR defines static local task for elasticsearch_helper_index_management module. Local task is grouped under Elasticsearch Helper settings page.