### PR TITLE
Clear queue confirmation form extends ConfirmFormBase

### DIFF
--- a/src/Form/IndexConfirmFormBase.php
+++ b/src/Form/IndexConfirmFormBase.php
@@ -49,7 +49,6 @@ abstract class IndexConfirmFormBase extends ConfirmFormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    /** @var \Drupal\Core\Routing\RouteMatchInterface $route_match */
     $route_match = $this->getRouteMatch();
 
     /** @var \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface $index_plugin */

--- a/src/Form/QueueClearConfirmForm.php
+++ b/src/Form/QueueClearConfirmForm.php
@@ -2,14 +2,16 @@
 
 namespace Drupal\elasticsearch_helper_index_management\Form;
 
+use Drupal\Core\Form\ConfirmFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Queue\QueueFactory;
+use Drupal\Core\Url;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Queue clear confirmation form.
  */
-class QueueClearConfirmForm extends IndexConfirmFormBase {
+class QueueClearConfirmForm extends ConfirmFormBase {
 
   /**
    * @var \Drupal\Core\Queue\QueueInterface
@@ -45,6 +47,13 @@ class QueueClearConfirmForm extends IndexConfirmFormBase {
   /**
    * {@inheritdoc}
    */
+  public function getCancelUrl() {
+    return new Url('elasticsearch_helper_index_management.index.list');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getDescription() {
     $t_args = ['@count' => $this->indexingQueue->numberOfItems()];
 
@@ -65,8 +74,6 @@ class QueueClearConfirmForm extends IndexConfirmFormBase {
     $this->indexingQueue->deleteQueue();
 
     $this->messenger()->addStatus('Indexing queue has been cleared.');
-
-    parent::submitForm($form, $form_state);
   }
 
 }


### PR DESCRIPTION
- `QueueClearConfirmForm` is not related to any index, hence no reason to
  extend index-aware `IndexConfirmFormBase`.