### PR TITLE
Clear entity indexing status when entity is deleted

### DIFF
--- a/elasticsearch_helper_index_management.module
+++ b/elasticsearch_helper_index_management.module
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @file
+ *
+ * This module provides Elasticsearch index plugin management functionality.
+ */
+
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Implements hook_entity_delete().
+ */
+function elasticsearch_helper_index_management_entity_delete(EntityInterface $entity) {
+  /** @var \Drupal\elasticsearch_helper_index_management\IndexingStatusOperationManagerInterface $status_manager */
+  $status_manager = \Drupal::service('elasticsearch_helper_index_management.index_status_operation_manager');
+
+  // Remove all reference to an entity in indexing status table.
+  $status_manager->deleteIndexingStatus($entity);
+}

--- a/src/EventSubscriber/IndexingStatus.php
+++ b/src/EventSubscriber/IndexingStatus.php
@@ -73,12 +73,6 @@ class IndexingStatus implements EventSubscriberInterface {
         $this->indexingStatusOperationManager->setSuccessIndexingStatus($request_wrapper->getObject(), $request_wrapper->getPluginInstance());
       }
     }
-    elseif ($operation == ElasticsearchOperations::DOCUMENT_DELETE) {
-      if ($this->isDeleteResultSuccessful($result)) {
-        // Mark indexing status as successful.
-        $this->indexingStatusOperationManager->deleteIndexingStatus($request_wrapper->getObject(), $request_wrapper->getPluginInstance());
-      }
-    }
   }
 
   /**
@@ -92,19 +86,6 @@ class IndexingStatus implements EventSubscriberInterface {
     $body = $result->getResultBody();
 
     return isset($body['result']) && in_array($body['result'], ['created', 'updated']);
-  }
-
-  /**
-   * Returns TRUE if document delete result is successful.
-   *
-   * @param \Drupal\elasticsearch_helper\ElasticsearchRequestResultInterface $result
-   *
-   * @return bool
-   */
-  protected function isDeleteResultSuccessful(ElasticsearchRequestResultInterface $result) {
-    $body = $result->getResultBody();
-
-    return isset($body['result']) && $body['result'] == 'deleted';
   }
 
 }

--- a/src/EventSubscriber/IndexingStatus.php
+++ b/src/EventSubscriber/IndexingStatus.php
@@ -53,7 +53,7 @@ class IndexingStatus implements EventSubscriberInterface {
   public function onOperationError(ElasticsearchOperationErrorEvent $event) {
     if ($event->getOperation() == ElasticsearchOperations::DOCUMENT_INDEX && $object = $event->getObject()) {
       // Mark indexing status as failed.
-      $this->indexingStatusOperationManager->setErrorIndexingStatus($event->getPluginInstance(), $object);
+      $this->indexingStatusOperationManager->setErrorIndexingStatus($object, $event->getPluginInstance());
     }
   }
 
@@ -70,13 +70,13 @@ class IndexingStatus implements EventSubscriberInterface {
     if ($operation == ElasticsearchOperations::DOCUMENT_INDEX) {
       if ($this->isIndexResultSuccessful($result)) {
         // Mark indexing status as successful.
-        $this->indexingStatusOperationManager->setSuccessIndexingStatus($request_wrapper->getPluginInstance(), $request_wrapper->getObject());
+        $this->indexingStatusOperationManager->setSuccessIndexingStatus($request_wrapper->getObject(), $request_wrapper->getPluginInstance());
       }
     }
     elseif ($operation == ElasticsearchOperations::DOCUMENT_DELETE) {
       if ($this->isDeleteResultSuccessful($result)) {
         // Mark indexing status as successful.
-        $this->indexingStatusOperationManager->deleteIndexingStatus($request_wrapper->getPluginInstance(), $request_wrapper->getObject());
+        $this->indexingStatusOperationManager->deleteIndexingStatus($request_wrapper->getObject(), $request_wrapper->getPluginInstance());
       }
     }
   }

--- a/src/IndexingStatusManager.php
+++ b/src/IndexingStatusManager.php
@@ -7,6 +7,8 @@ use Drupal\Core\Database\Connection;
 
 /**
  * Defines indexing status manager.
+ *
+ * Where possible, use indexing status operation manager to change statuses.
  */
 class IndexingStatusManager implements IndexingStatusManagerInterface {
 

--- a/src/IndexingStatusManagerInterface.php
+++ b/src/IndexingStatusManagerInterface.php
@@ -28,10 +28,10 @@ interface IndexingStatusManagerInterface {
   /**
    * Clear all status items.
    *
-   * @param array $parameter
+   * @param array $parameters
    *   An array of parameters.
    */
-  public function clear(array $parameter = []);
+  public function clear(array $parameters = []);
 
   /**
    * Get all status items.

--- a/src/IndexingStatusOperationManager.php
+++ b/src/IndexingStatusOperationManager.php
@@ -29,41 +29,41 @@ class IndexingStatusOperationManager implements IndexingStatusOperationManagerIn
   /**
    * {@inheritdoc}
    */
-  public function setSuccessIndexingStatus(ElasticsearchIndexInterface $index_plugin, $object) {
+  public function setSuccessIndexingStatus($object, ElasticsearchIndexInterface $index_plugin) {
     if ($object instanceof EntityInterface) {
-      $this->setEntityIndexingStatus($index_plugin, $object, IndexingStatusManagerInterface::STATUS_SUCCESS);
+      $this->setEntityIndexingStatus($object, IndexingStatusManagerInterface::STATUS_SUCCESS, $index_plugin);
     }
   }
 
   /**
    * {@inheritdoc}
    */
-  public function setErrorIndexingStatus(ElasticsearchIndexInterface $index_plugin, $object) {
+  public function setErrorIndexingStatus($object, ElasticsearchIndexInterface $index_plugin) {
     if ($object instanceof EntityInterface) {
-      $this->setEntityIndexingStatus($index_plugin, $object, IndexingStatusManagerInterface::STATUS_ERROR);
+      $this->setEntityIndexingStatus($object, IndexingStatusManagerInterface::STATUS_ERROR, $index_plugin);
     }
   }
 
   /**
    * {@inheritdoc}
    */
-  public function deleteIndexingStatus(ElasticsearchIndexInterface $index_plugin, $object) {
+  public function deleteIndexingStatus($object, ElasticsearchIndexInterface $index_plugin = NULL) {
     if ($object instanceof EntityInterface) {
-      $this->deleteEntityIndexingStatus($index_plugin, $object);
+      $this->deleteEntityIndexingStatus($object, $index_plugin);
     }
   }
 
   /**
    * Sets indexing status for index-able entity.
    *
-   * @param \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface $index_plugin
-   *   The Elasticsearch index plugin which is indexing the object.
    * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The index-able entity.
    * @param $status
    *   Status name.
+   * @param \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface $index_plugin
+   *   The Elasticsearch index plugin which is indexing the object.
    */
-  protected function setEntityIndexingStatus(ElasticsearchIndexInterface $index_plugin, EntityInterface $entity, $status) {
+  protected function setEntityIndexingStatus(EntityInterface $entity, $status, ElasticsearchIndexInterface $index_plugin) {
     $this->indexingStatusManager->updateStatus([
       'index_plugin' => $index_plugin->getPluginId(),
       'status' => $status,
@@ -75,15 +75,20 @@ class IndexingStatusOperationManager implements IndexingStatusOperationManagerIn
   /**
    * Deletes indexing status for given entity.
    *
-   * @param \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface $index_plugin
    * @param \Drupal\Core\Entity\EntityInterface $entity
+   * @param \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface $index_plugin
    */
-  protected function deleteEntityIndexingStatus(ElasticsearchIndexInterface $index_plugin, EntityInterface $entity) {
-    $this->indexingStatusManager->clear([
-      'index_plugin' => $index_plugin->getPluginId(),
+  protected function deleteEntityIndexingStatus(EntityInterface $entity, ElasticsearchIndexInterface $index_plugin = NULL) {
+    $conditions = [
       'id' => $entity->id(),
       'entity_type' => $entity->getEntityTypeId(),
-    ]);
+    ];
+
+    if ($index_plugin) {
+      $conditions['index_plugin'] = $index_plugin->getPluginId();
+    }
+
+    $this->indexingStatusManager->clear($conditions);
   }
 
 }

--- a/src/IndexingStatusOperationManagerInterface.php
+++ b/src/IndexingStatusOperationManagerInterface.php
@@ -12,31 +12,31 @@ interface IndexingStatusOperationManagerInterface {
   /**
    * Sets successful indexing status for index-able object.
    *
-   * @param \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface $index_plugin
-   *   The Elasticsearch index plugin which is indexing the object.
    * @param mixed $object
    *   The index-able object.
+   * @param \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface $index_plugin
+   *   The Elasticsearch index plugin which is indexing the object.
    */
-  public function setSuccessIndexingStatus(ElasticsearchIndexInterface $index_plugin, $object);
+  public function setSuccessIndexingStatus($object, ElasticsearchIndexInterface $index_plugin);
 
   /**
    * Sets failing indexing status for index-able object.
    *
-   * @param \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface $index_plugin
-   *   The Elasticsearch index plugin which is indexing the object.
    * @param mixed $object
    *   The index-able object.
+   * @param \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface $index_plugin
+   *   The Elasticsearch index plugin which is indexing the object.
    */
-  public function setErrorIndexingStatus(ElasticsearchIndexInterface $index_plugin, $object);
+  public function setErrorIndexingStatus($object, ElasticsearchIndexInterface $index_plugin);
 
   /**
    * Deletes indexing status item from the table.
    *
-   * @param \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface $index_plugin
    * @param $object
-   *
-   * @return mixed
+   *   The index-able object.
+   * @param \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface $index_plugin|null
+   *   The Elasticsearch index plugin which is indexing the object.
    */
-  public function deleteIndexingStatus(ElasticsearchIndexInterface $index_plugin, $object);
+  public function deleteIndexingStatus($object, ElasticsearchIndexInterface $index_plugin = NULL);
 
 }


### PR DESCRIPTION
Currently entity indexing status entry is removed based on DELETE request to Elasticsearch document endpoint. This causes problems when entity indexing status entry is orphaned if Elasticsearch is not available.

This change removes entity indexing status when entity is deleted from Drupal.

Also, signature of methods in `IndexingStatusOperationManagerInterface` are changed to place the index-able object (incl. entity) as first parameter and index plugin instance as a second parameter to allow removal of entity status without explicit index plugin.

Steps to review:
1. Run ``lando drush cr`
2. Create or edit a node, see that indexing status is inserted into `elasticsearch_helper_indexing_status` table.
3. Stop Elasticsearch instance in Docker dashboard.
4. Delete the node and see that indexing status is removed from `elasticsearch_helper_indexing_status` table.