### PR TITLE
Indexing status for entity is removed when entity document is removed from the index

### DIFF
--- a/src/EventSubscriber/IndexingStatus.php
+++ b/src/EventSubscriber/IndexingStatus.php
@@ -73,6 +73,12 @@ class IndexingStatus implements EventSubscriberInterface {
         $this->indexingStatusOperationManager->setSuccessIndexingStatus($request_wrapper->getObject(), $request_wrapper->getPluginInstance());
       }
     }
+    elseif ($operation == ElasticsearchOperations::DOCUMENT_DELETE) {
+      if ($this->isDeleteResultSuccessful($result)) {
+        // Delete indexing status on removal from index.
+        $this->indexingStatusOperationManager->deleteIndexingStatus($request_wrapper->getObject(), $request_wrapper->getPluginInstance());
+      }
+    }
   }
 
   /**
@@ -87,5 +93,19 @@ class IndexingStatus implements EventSubscriberInterface {
 
     return isset($body['result']) && in_array($body['result'], ['created', 'updated']);
   }
+
+  /**
+   * Returns TRUE if document delete result is successful.
+   *
+   * @param \Drupal\elasticsearch_helper\ElasticsearchRequestResultInterface $result
+   *
+   * @return bool
+   */
+  protected function isDeleteResultSuccessful(ElasticsearchRequestResultInterface $result) {
+    $body = $result->getResultBody();
+
+    return isset($body['result']) && $body['result'] == 'deleted';
+  }
+
 
 }

--- a/src/EventSubscriber/IndexingStatus.php
+++ b/src/EventSubscriber/IndexingStatus.php
@@ -107,5 +107,4 @@ class IndexingStatus implements EventSubscriberInterface {
     return isset($body['result']) && $body['result'] == 'deleted';
   }
 
-
 }


### PR DESCRIPTION
This is a partial rollback of change in https://github.com/wunderio/elasticsearch_helper_index_management/pull/14.