### PR TITLE
New table index for fields "index_plugin", "id" and "entity_type" is added

### DIFF
--- a/elasticsearch_helper_index_management.install
+++ b/elasticsearch_helper_index_management.install
@@ -54,6 +54,7 @@ function elasticsearch_helper_index_management_schema() {
       'object' => ['id'],
       'entity' => ['id', 'entity_type'],
       'status' => ['status'],
+      'index_plugin_entity' => ['index_plugin', 'id', 'entity_type'],
     ],
   ];
 
@@ -65,4 +66,20 @@ function elasticsearch_helper_index_management_schema() {
  */
 function elasticsearch_helper_index_management_update_8001() {
   drupal_install_schema('elasticsearch_helper_index_management');
+}
+
+/**
+ * Add plugin/entity ID/entity type field index to the table.
+ */
+function elasticsearch_helper_index_management_update_8002() {
+  $database = \Drupal::database();
+  // Get table schema.
+  $table_schema = elasticsearch_helper_index_management_schema()['elasticsearch_helper_indexing_status'];
+  // Add index.
+  $database->schema()->addIndex(
+    'elasticsearch_helper_indexing_status',
+    'index_plugin_entity',
+    ['index_plugin', 'id', 'entity_type'],
+    $table_schema
+  );
 }


### PR DESCRIPTION
Drupal `merge` query performs many `SELECT 1 AS expression` queries on `index_plugin`, `id` and `entity_type` fields. This change will make these read queries a bit faster.