### PR TITLE
Method setEntityIndexingStatus() is added to IndexingStatusOperationManagerInterface

### DIFF
--- a/src/IndexingStatusOperationManager.php
+++ b/src/IndexingStatusOperationManager.php
@@ -54,16 +54,9 @@ class IndexingStatusOperationManager implements IndexingStatusOperationManagerIn
   }
 
   /**
-   * Sets indexing status for index-able entity.
-   *
-   * @param \Drupal\Core\Entity\EntityInterface $entity
-   *   The index-able entity.
-   * @param $status
-   *   Status name.
-   * @param \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface $index_plugin
-   *   The Elasticsearch index plugin which is indexing the object.
+   * {@inheritdoc}
    */
-  protected function setEntityIndexingStatus(EntityInterface $entity, $status, ElasticsearchIndexInterface $index_plugin) {
+  public function setEntityIndexingStatus(EntityInterface $entity, $status, ElasticsearchIndexInterface $index_plugin) {
     $this->indexingStatusManager->updateStatus([
       'index_plugin' => $index_plugin->getPluginId(),
       'status' => $status,
@@ -76,7 +69,7 @@ class IndexingStatusOperationManager implements IndexingStatusOperationManagerIn
    * Deletes indexing status for given entity.
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
-   * @param \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface $index_plugin
+   * @param \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface|null $index_plugin
    */
   protected function deleteEntityIndexingStatus(EntityInterface $entity, ElasticsearchIndexInterface $index_plugin = NULL) {
     $conditions = [

--- a/src/IndexingStatusOperationManagerInterface.php
+++ b/src/IndexingStatusOperationManagerInterface.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\elasticsearch_helper_index_management;
 
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface;
 
 /**
@@ -34,9 +35,21 @@ interface IndexingStatusOperationManagerInterface {
    *
    * @param $object
    *   The index-able object.
-   * @param \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface $index_plugin|null
+   * @param \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface|null $index_plugin
    *   The Elasticsearch index plugin which is indexing the object.
    */
   public function deleteIndexingStatus($object, ElasticsearchIndexInterface $index_plugin = NULL);
+
+  /**
+   * Sets indexing status for index-able entity.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The index-able entity.
+   * @param $status
+   *   Status name.
+   * @param \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface $index_plugin
+   *   The Elasticsearch index plugin which is indexing the object.
+   */
+  public function setEntityIndexingStatus(EntityInterface $entity, $status, ElasticsearchIndexInterface $index_plugin);
 
 }


### PR DESCRIPTION
This change allows custom imlpementations to set arbitrary statuses (e.g., `partial`) to indicate different indexing statuses.

Still, the two statuses that are supported by the module remain `error` and `success`.