### PR TITLE
Introduce more fine-grained permissions for the module

### DIFF
--- a/elasticsearch_helper_index_management.links.menu.yml
+++ b/elasticsearch_helper_index_management.links.menu.yml
@@ -3,3 +3,9 @@ elasticsearch_helper_index_management.indices:
   description: 'Manage Elasticsearch indexes plugins'
   route_name: elasticsearch_helper_index_management.index.list
   parent: elasticsearch_helper.elasticsearch_helper_settings_form
+elasticsearch_helper_index_management.indices_direct_link:
+  title: 'Elasticsearch Helper Indices'
+  route_name: elasticsearch_helper_index_management.index.list
+  description: 'Manage Elasticsearch indexes plugins'
+  parent: system.admin_config_search
+  class: Drupal\elasticsearch_helper_index_management\Plugin\Menu\IndicesMenuLink

--- a/elasticsearch_helper_index_management.permissions.yml
+++ b/elasticsearch_helper_index_management.permissions.yml
@@ -1,0 +1,19 @@
+administer elasticsearch helper index plugins:
+  title: 'Administer Elasticsearch Helper Index Plugins'
+  description: 'Allow users to administer Elasticsearch helper index plugins'
+  restrict access: true
+
+allow all elasticsearch helper index plugin operations:
+  title: 'Allow all Elasticsearch Helper Index Plugin operations'
+
+allow reindex elasticsearch helper index plugin operation:
+  title: 'Allow reindex Elasticsearch Helper Index Plugin operation'
+
+allow setup elasticsearch helper index plugin operation:
+  title: 'Allow setup Elasticsearch Helper Index Plugin operation'
+
+allow drop elasticsearch helper index plugin operation:
+  title: 'Allow drop Elasticsearch Helper Index Plugin operation'
+
+allow queue clear elasticsearch helper index plugin operation:
+  title: 'Allow clear indexing queue Elasticsearch Helper Index Plugin operation'

--- a/elasticsearch_helper_index_management.routing.yml
+++ b/elasticsearch_helper_index_management.routing.yml
@@ -4,7 +4,7 @@ elasticsearch_helper_index_management.index.list:
     _form: '\Drupal\elasticsearch_helper_index_management\Form\IndexListForm'
     _title: 'Index plugins'
   requirements:
-    _permission: 'configure elasticsearch helper'
+    _permission: 'administer elasticsearch helper index plugins'
 
 elasticsearch_helper_index_management.index.view:
   path: '/admin/config/search/elasticsearch_helper/index/{plugin}'
@@ -16,7 +16,7 @@ elasticsearch_helper_index_management.index.view:
       plugin:
         type: elasticsearch_index_plugin
   requirements:
-    _permission: 'configure elasticsearch helper'
+    _permission: 'administer elasticsearch helper index plugins'
 
 elasticsearch_helper_index_management.index.setup:
   path: '/admin/config/search/elasticsearch_helper/index/{plugin}/setup'
@@ -28,7 +28,7 @@ elasticsearch_helper_index_management.index.setup:
       plugin:
         type: elasticsearch_index_plugin
   requirements:
-    _permission: 'configure elasticsearch helper'
+    _permission: 'allow all elasticsearch helper index plugin operations+allow setup elasticsearch helper index plugin operation'
 
 elasticsearch_helper_index_management.index.reindex:
   path: '/admin/config/search/elasticsearch_helper/index/{plugin}/reindex'
@@ -40,7 +40,7 @@ elasticsearch_helper_index_management.index.reindex:
       plugin:
         type: elasticsearch_index_plugin
   requirements:
-    _permission: 'configure elasticsearch helper'
+    _permission: 'allow all elasticsearch helper index plugin operations+allow reindex elasticsearch helper index plugin operation'
 
 elasticsearch_helper_index_management.index.queue_clear:
   path: '/admin/config/search/elasticsearch_helper/index/clear-queue'
@@ -48,7 +48,7 @@ elasticsearch_helper_index_management.index.queue_clear:
     _form: '\Drupal\elasticsearch_helper_index_management\Form\QueueClearConfirmForm'
     _title: 'Clear indexing queue'
   requirements:
-    _permission: 'configure elasticsearch helper'
+    _permission: 'allow all elasticsearch helper index plugin operations+allow queue clear elasticsearch helper index plugin operation'
 
 elasticsearch_helper_index_management.index.drop:
   path: '/admin/config/search/elasticsearch_helper/index/{plugin}/drop'
@@ -60,4 +60,4 @@ elasticsearch_helper_index_management.index.drop:
       plugin:
         type: elasticsearch_index_plugin
   requirements:
-    _permission: 'configure elasticsearch helper'
+    _permission: 'allow all elasticsearch helper index plugin operations+allow drop elasticsearch helper index plugin operation'

--- a/src/Plugin/Menu/IndicesMenuLink.php
+++ b/src/Plugin/Menu/IndicesMenuLink.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Drupal\elasticsearch_helper_index_management\Plugin\Menu;
+
+use Drupal\Core\Menu\MenuLinkDefault;
+use Drupal\Core\Menu\StaticMenuLinkOverridesInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class IndicesMenuLink extends MenuLinkDefault {
+
+  /**
+   * The static menu link service used to store updates to weight/parent etc.
+   *
+   * @var \Drupal\Core\Menu\StaticMenuLinkOverridesInterface
+   */
+  protected $staticOverride;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $currentUser;
+
+  /**
+   * Constructs a new MenuLinkDefault.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Menu\StaticMenuLinkOverridesInterface $static_override
+   *   The static override storage.
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, StaticMenuLinkOverridesInterface $static_override, AccountInterface $current_user) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $static_override);
+
+    $this->currentUser = $current_user;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('menu_link.static.overrides'),
+      $container->get('current_user')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isEnabled() {
+    $roles = $this->currentUser->getRoles();
+
+    if (
+      !$this->currentUser->hasPermission('configure elasticsearch helper') && !in_array('administrator', $roles)) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+}


### PR DESCRIPTION
This PR separates permissions from ESH module and  introduces more fine-grained permissions for the elasticsearch_helper_index_management module. 

This change won't impact on users having `administrator `role but provides more fine-grained permissions for index plugin operations in cases where client should have limited access to some of the index plugin operations (but not necessarily for all ESH related operations / actions).

Following permission roles added:
- Administer Elasticsearch Helper Index Plugins (restrict access: true)
- Allow all Elasticsearch Helper Index Plugin operations
  - Allows permission for all operations with one permission settings.
  
- Allow clear indexing queue Elasticsearch Helper Index Plugin operation
- Allow drop Elasticsearch Helper Index Plugin operation
- Allow reindex Elasticsearch Helper Index Plugin operation
- Allow setup Elasticsearch Helper Index Plugin operation

Index Plugin operation permissions are conditional (OR), either `Allow all Elasticsearch Helper Index Plugin operations` or permission for operation in question is required.